### PR TITLE
Handle missing keyframes as repeats

### DIFF
--- a/src/m.jta.js
+++ b/src/m.jta.js
@@ -274,20 +274,43 @@ please.gl.__jta_add_action = function (root_node, action_name, raw_data) {
             ITER_PROPS(object_id, start_updates) {
                 var obj_start = start_updates[object_id];
                 var obj_end = end_updates[object_id];
-                if (obj_start && obj_end) {
-                    var node = find_object(object_id);
-                    if (node) {
-                        ITER(i, attr_constants) {
-                            var attr = attr_constants[i];
-                            if (obj_start[attr] && obj_end[attr]) {
-                                var lhs = obj_start[attr];
-                                var rhs = obj_end[attr];
-                                if (skip_to) {
-                                    lhs = please.mix(lhs, rhs, skip_to);
-                                }
-                                var path = please.linear_path(lhs, rhs)
-                                node[attr] = please.path_driver(path, speed);
+                if (!obj_end) {
+                    obj_end = obj_start;
+                }
+                var node = find_object(object_id);
+                if (node) {
+                    ITER(i, attr_constants) {
+                        var attr = attr_constants[i];
+                        if (obj_start[attr] && obj_end[attr]) {
+                            var lhs = obj_start[attr];
+                            var rhs = obj_end[attr];
+                            if (skip_to) {
+                                lhs = please.mix(lhs, rhs, skip_to);
                             }
+                            var path = please.linear_path(lhs, rhs);
+                            node[attr] = please.path_driver(path, speed);
+                        }
+                    }
+                }
+            }
+            ITER_PROPS(object_id, end_updates) {
+                var obj_end = end_updates[object_id];
+                if (start_updates[object_id]) {
+                    // This has been handled above.
+                    continue;
+                }
+                var node = find_object(object_id);
+                if (node) {
+                    ITER(i, attr_constants) {
+                        var attr = attr_constants[i];
+                        if (obj_end[attr]) {
+                            var lhs = node[attr];
+                            var rhs = obj_end[attr];
+                            if (skip_to) {
+                                lhs = please.mix(lhs, rhs, skip_to);
+                            }
+                            var path = please.linear_path(lhs, rhs);
+                            node[attr] = please.path_driver(path, speed);
                         }
                     }
                 }
@@ -305,6 +328,12 @@ please.gl.__jta_add_action = function (root_node, action_name, raw_data) {
         frame_set.push({
             "speed" : (high.start - low.start),
             "callback" : make_frame_callback(low.updates, high.updates),
+        });
+    }
+    if (high.start < raw_data.duration) {
+        frame_set.push({
+            "speed" : (raw_data.duration - high.start),
+            "callback" : make_frame_callback(high.updates, {}),
         });
     }
 


### PR DESCRIPTION
M.GRL doesn't interpolate when the preceding keyframe is not present for a property.  If the following keyframe for the property is also missing, it doesn't do anything at all.

This pull request fixes that.