### PR TITLE
Several minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 all:
 	./build.sh
 
-.PHONY: all
+clean:
+	git checkout \
+		mgrl.js \
+		templates/basic_project.zip \
+		templates/basic_project/libs/mgrl.js \
+		templates/common_assets/libs/mgrl.js
+
+.PHONY: all clean

--- a/src/m.gani.js
+++ b/src/m.gani.js
@@ -281,9 +281,9 @@ please.media.__AnimationInstance = function (animation_data) {
     // get_current_frame retrieves the frame that currently should be
     // visible
     ani.get_current_frame = function (progress) {
-        if (progress > ani.data.durration) {
+        if (progress > ani.data.duration) {
             if (ani.data.looping && !typeof(ani.data.setbackto) === "number") {
-                progress = progress % ani.data.durration;
+                progress = progress % ani.data.duration;
             }
             else {
                 return -1;
@@ -483,7 +483,7 @@ please.media.__AnimationData = function (gani_text, uri) {
         */
 
         "base_speed" : 50,
-        "durration" : 0,
+        "duration" : 0,
         
         "single_dir" : false,
         "looping" : false,
@@ -679,9 +679,9 @@ please.media.__AnimationData = function (gani_text, uri) {
         }
     }
 
-    // calculate animation durration
+    // calculate animation duration
     ITER(i, ani.frames) {
-        ani.durration += ani.frames[i].wait;
+        ani.duration += ani.frames[i].wait;
     };
 
 

--- a/src/m.media.js
+++ b/src/m.media.js
@@ -343,7 +343,7 @@ please.media.__try_media_ready = function () {
 //
 please.media.guess_type = function (file_name) {
     var type_map = {
-        "img" : [".png", ".gif", ".jpg", ".jpeg"],
+        "img" : [".png", ".gif", ".jpg", ".jpeg", ".svg"],
         "jta" : [".jta"],
         "gani" : [".gani"],
         "audio" : [".wav", ".mp3", ".ogg"],


### PR DESCRIPTION
This request contains 3 commits with a small change each.

A make target is added for "make clean", which restores the repository version of generated files; this makes the output of "git diff" readable.

In m.gani.js, "duration" was consistently spelled as "durration".

".svg" is added as an image type.