### PR TITLE
include subdir in gani action name

### DIFF
--- a/src/m.gani.js
+++ b/src/m.gani.js
@@ -506,7 +506,11 @@ please.media.__AnimationData = function (gani_text, uri) {
     };
 
     var get_action_name = function (uri) {
-        var name = uri.split("/").slice(-1)[0];
+        var name = uri;
+        var path = please.media.search_paths.gani;
+        if (name.startsWith(path)) {
+            name = name.slice(path.length);
+        }
         if (name.endsWith(".gani")) {
             name = name.slice(0, -5);
         }
@@ -800,7 +804,6 @@ please.media.__AnimationData = function (gani_text, uri) {
         node.__current_gani = null;
         node.__current_frame = null;
 
-        var action_name = get_action_name(this.__uri);
         if (setup_callback) {
             setup_callback(this);
         }


### PR DESCRIPTION
get_action_name() currently turns "gani/main/walk.gani" into "walk".  This change turns it into "main/walk" instead, thus allowing the use of actions with equal names in different subdirs.

I also removed a line that was left over in my previous PR, which created a variable that wasn't used.