### PR TITLE
Update Blender addon to Blender 2.80.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 *#
 .#*
 *.pyc
-/apps/jta_tool/dist/
-/apps/jta_tool/*.egg-info
 *.blend?
 /src/tmp/
 /src/Makefile
+/apps/blender_addon/io_scene_jta.zip

--- a/apps/blender_addon/io_scene_jta/__init__.py
+++ b/apps/blender_addon/io_scene_jta/__init__.py
@@ -22,7 +22,7 @@ bl_info = {
     "name": "Export Mondaux Graphics and Recreation Library (.jta)",
     "author": "Aeva Palecek",
     "version": (0, 0, 0),
-    "blender": (2, 72, 0),
+    "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Exports models and animation to M.GRL's json-based model format (.jta).",
     "warning": "Incomplete support, work in progress.",
@@ -49,7 +49,7 @@ from bpy_extras.io_utils import (ImportHelper,
                                  )
 
 
-class ExportJTA(bpy.types.Operator, ExportHelper):
+class JTA_OT_ExportJTA(bpy.types.Operator, ExportHelper):
     """Save a M.GRL JTA File"""
 
     bl_idname = "export_scene.jta"
@@ -57,31 +57,31 @@ class ExportJTA(bpy.types.Operator, ExportHelper):
     bl_options = {"PRESET"}
 
     filename_ext = ".jta"
-    filter_glob = StringProperty(
+    filter_glob: StringProperty(
         default="*.jta",
         options={"HIDDEN"},
     )
 
     # metadata
-    meta_author = StringProperty(
+    meta_author: StringProperty(
         name="Author",
         description="Name or names to which this file should be attributed to.",
         default="",
     )
 
-    meta_url = StringProperty(
+    meta_url: StringProperty(
         name="Attribution URL",
         description="URL to which this file should be attributed to.",
         default="",
     )
 
-    meta_src_url = StringProperty(
+    meta_src_url: StringProperty(
         name="Source work URL",
         description="URL or URLs to works of which this work is based on derived from.",
         default="",
     )
 
-    meta_license = EnumProperty(
+    meta_license: EnumProperty(
         name="License",
         description="Copyright license for this work.",
         items=[
@@ -102,32 +102,32 @@ class ExportJTA(bpy.types.Operator, ExportHelper):
         default="none",
     )
 
-    use_selection = BoolProperty(
+    use_selection: BoolProperty(
         name="Selection Only",
         description="Export selected objects only",
         default=False,
     )
 
-    use_mesh_modifiers = BoolProperty(
+    use_mesh_modifiers: BoolProperty(
         name="Apply Modifiers",
         description="Apply modifiers (preview resolution)",
         default=True,
     )
 
-    trim_paths = BoolProperty(
+    trim_paths: BoolProperty(
         name="Truncate Paths",
         description="For externally referenced files, only store the file name of the asset.",
         default = True,
     )
 
-    pack_images = BoolProperty(
+    pack_images: BoolProperty(
         name="Pack All Images (caution!)",
         description="Embeds images in the exported file instead of storing only referencs."
         "  Use sparingly as this will *GREATLY* inflate the size of the exported file!!!",
         default=False,
     )
 
-    global_scale = FloatProperty(
+    global_scale: FloatProperty(
         name="Scale",
         min=0.001, max=1000.0,
         default=1.0,
@@ -147,17 +147,23 @@ class ExportJTA(bpy.types.Operator, ExportHelper):
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportJTA.bl_idname, text="M.GRL (.jta)")
+    self.layout.operator(JTA_OT_ExportJTA.bl_idname, text="M.GRL (.jta)")
 
+
+classes = (JTA_OT_ExportJTA,)
 
 def register():
-    bpy.utils.register_module(__name__)
-    bpy.types.INFO_MT_file_export.append(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+    from bpy.utils import register_class
+    for cls in classes:
+        register_class(cls)
 
 
 def unregister():
-    bpy.utils.unregister_module(__name__)
-    bpy.types.INFO_MT_file_export.remove(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
+    from bpy.utils import unregister_class
+    for cls in classes:
+        unregister_class(cls)
 
 
 if __name__ == "__main__":

--- a/apps/blender_addon/io_scene_jta/export_jta.py
+++ b/apps/blender_addon/io_scene_jta/export_jta.py
@@ -111,7 +111,7 @@ def save(operator, context, options={}):
     export_rigs = []
     for selection in selections:
         used_selection = False
-        if selection.dupli_type == "NONE" and selection.type == "MESH":
+        if selection.instance_type == "NONE" and selection.type == "MESH":
             model = Model(selection, scene, options, texture_store)
             if not model.face_vertices:
                 print("Skipping empty mesh {0}".format(selection))
@@ -130,8 +130,8 @@ def save(operator, context, options={}):
             used_selection = True
 
         else:
-            if selection.dupli_type != "NONE":
-                print("Skipping object {0} of dupli_type {1}".format(selection, selection.dupli_type))
+            if selection.instance_type != "NONE":
+                print("Skipping object {0} of instance_type {1}".format(selection, selection.instance_type))
             if selection.type != "MESH":
                 print("Skipping non-mesh object {0}".format(selection))
 

--- a/apps/blender_addon/io_scene_jta/model_data.py
+++ b/apps/blender_addon/io_scene_jta/model_data.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 
+import bpy
 import bmesh
 import mathutils
 
@@ -66,14 +67,13 @@ class Model(Exportable):
         Exportable.__init__(self, selection, scene, options)
 
         self.texture_store = texture_store
-        self.mesh = self.obj.to_mesh(
-            scene, options["use_mesh_modifiers"], "PREVIEW", calc_tessface=False)
+        self.mesh = self.obj.to_mesh(bpy.context.depsgraph, options["use_mesh_modifiers"])
         self.mesh.transform(mathutils.Matrix.Scale(options["global_scale"], 4))
         self.__triangulate()
 
         self.use_smooth = self.__is_smooth_shading()
         self.use_weights = len(self.obj.vertex_groups) > 0
-        self.texture_count = len(self.mesh.uv_textures)
+        self.texture_count = len(self.mesh.uv_layers)
         self.__generate_vertices()
 
         self.attr_struct = None

--- a/apps/blender_addon/io_scene_jta/texture_data.py
+++ b/apps/blender_addon/io_scene_jta/texture_data.py
@@ -57,7 +57,7 @@ class TextureStore(object):
             return None
         
         renderer = bpy.context.scene.render.engine
-        if renderer == "CYCLES":
+        if renderer in ("CYCLES", "BLENDER_EEVEE"):
             image = self.__cycles_refcode_target(model)
         elif renderer == "BLENDER_RENDER":
             image = self.__blender_refcode_target(model)
@@ -68,6 +68,8 @@ class TextureStore(object):
             assert image.file_format in ["PNG", "JPEG"]
             if image.filepath == "" or self.force_pack:
                 if image.filepath == "":
+                    if image.packed_file is None:
+                        raise ValueError("Texture is not saved and not packed.")
                     return self.pack_image(BytesIO(image.packed_file.data), image.file_format)
                 else:
                     return self.pack_image(open(image.filepath, "r"), image.file_format)


### PR DESCRIPTION
With Blender 2.80 a lot of the API has changed. The addon is updated to reflect
those changes.

The only thing I'm not entirely sure about is that I use bpy.context to get the depsgraph. If there's another way to get it, it's probably better, because the context is related to what is on screen at the moment and that shouldn't influence the exported result.